### PR TITLE
write(post): 2014年の振り返り

### DIFF
--- a/_posts/2014/2014-12-31-oss-in-2014.md
+++ b/_posts/2014/2014-12-31-oss-in-2014.md
@@ -37,6 +37,10 @@ tags:
 - [efcl/efcl.github.io](https://github.com/efcl/efcl.github.io)
 - [jser/jser.github.io](https://github.com/jser/jser.github.io)
 
+### コミットメッセージ
+
+[conventional-changelog/CONVENTIONS.md](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md "conventional-changelog/CONVENTIONS.md at master · ajoslin/conventional-changelog") のルールで書くようになった。(Angularチームのコミットメッセージルールが元)
+
 ### JavaScript
 
 JavaScriptは趣味であったため、あまり実用的なJavaScriptライブラリは書いてないです。


### PR DESCRIPTION
- [2014振り返り - damemo](http://dameleon.github.io/memo/2014/12/27/2014/)
- [ざっくり2014年の振り返り - watilde's blog](http://watilde.hatenablog.com/entry/2014/12/29/174246)
- [今年のOSSお焚き上げ - mizchi's blog](http://mizchi.hatenablog.com/entry/2014/12/28/184803)
- [2014年の振り返り - mizchi's blog](http://mizchi.hatenablog.com/entry/2014/12/30/142611)
- [2014年、技術しかしてない - ゆううきブログ](http://yuuki.hatenablog.com/entry/looking-back-2014)

みたいな振り返り記事
