### PR TITLE
ES6にライブラリを書き換えた話

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: ruby
 rvm:
 - 2.2.0
+before_install:
+- git fetch --unshallow
 install:
 - bundle install --without production --deployment
 - npm install

--- a/_posts/2015/2015-10-03-es5-to-es6.md
+++ b/_posts/2015/2015-10-03-es5-to-es6.md
@@ -138,3 +138,14 @@ jscs -x src/
 書き換えしなくてもBabelで変換するだけならES5のコードそのものをBabelで変換しても問題ないはずですが、中途半端に追加していくのはダルそうだったのでザクっと変換しました。
 
 書き換えするのにあるといいのは、カバレッジが高いテストコードですが、今回はそれの補強材として[Exampleテスト](http://efcl.info/2015/07/29/example-test-on-npm/ "Exampleテスト")を幾つか追加してから変換しました。
+
+textlintの作りは[ESLint](https://github.com/eslint/eslint "ESLint")の作りを大体継承してますが、
+ES5だとやっぱり見た目からどういう状態を持ってるのかが分かりにくい問題が起きやすい部分があると思います。
+
+特に[eslint.js](https://github.com/eslint/eslint/blob/v1.6.0/lib/eslint.js "eslint.js")は`api`という巨大なシングルトンみたいな感じになっています。
+このシングルトンの扱いをclass自体とそれをnewしたシングルトンオブジェクトをそれぞれexportするというパターンに修正したかったのもあります。
+
+- [textlint/textlint.js at 4a28a282e86d3b4b8f9c9f9449c512ec8bc560a0 · azu/textlint](https://github.com/azu/textlint/blob/4a28a282e86d3b4b8f9c9f9449c512ec8bc560a0/src/textlint.js#L37-L40 "textlint/textlint.js at 4a28a282e86d3b4b8f9c9f9449c512ec8bc560a0 · azu/textlint")
+- [テストを考慮した singleton の ES6 export ::ハブろぐ](http://havelog.ayumusato.com/develop/javascript/e666-singleton_export_with_es6.html "テストを考慮した singleton の ES6 export ::ハブろぐ")
+
+今回のES5 to ES6のリファクタリングでコード自体は見やすくなったのではないかなーと思います。

--- a/_posts/2015/2015-10-03-es5-to-es6.md
+++ b/_posts/2015/2015-10-03-es5-to-es6.md
@@ -103,8 +103,8 @@ xto6みたいに構造的にそのまま一致しない場合は変換できな�
 [ライブラリをES6で書いて公開する所から始めよう](http://efcl.info/2015/01/09/write-es6/ "ライブラリをES6で書いて公開する所から始めよう | Web Scratch")でやっているES6で書いたライブラリ構成になるということなので、`package.json`を色々書き換えます。
 
 - `"main"`のパスが変わってるなら変更
-- `.gitignore`の`/lib`を追加
-- `lib/`をGitの管理下から外す
+- `.gitignore`に`/lib`を追加
+- `lib/`をGitの管理下から外す(git rm)
 
 ### [JSCS](http://jscs.info/ "JSCS")でスタイルチェック
 

--- a/_posts/2015/2015-10-03-es5-to-es6.md
+++ b/_posts/2015/2015-10-03-es5-to-es6.md
@@ -1,0 +1,140 @@
+---
+title: "ES5で書かれたライブラリをES6に書き換える手順"
+author: azu
+layout: post
+date : 2015-10-03T13:23
+category: JavaScript
+tags:
+    - ES6
+    - JavaScript
+    - library
+    - textlint
+
+---
+
+[textlint](https://github.com/azu/textlint "textlint") 3.6.1でコードベースをES6に書き直して、特に問題無く動いてるっぽいのでどういう手順で書き換えたかについての話。
+
+- [Release Moving to ES6 · azu/textlint](https://github.com/azu/textlint/releases/tag/3.6.1 "Release Moving to ES6 · azu/textlint")
+
+具体的な作業は以下に残ってます。
+
+- [Move to ES6 · Issue #11 · azu/textlint](https://github.com/azu/textlint/issues/11 "Move to ES6 · Issue #11 · azu/textlint")
+- [to ES6 by azu · Pull Request #27 · azu/textlint](https://github.com/azu/textlint/pull/27 "to ES6 by azu · Pull Request #27 · azu/textlint")
+
+### 事前準備
+
+- テストを書く
+
+テストが書かれてると変換した時にエラーがスグ発見できるのでカバレッジが高いテストがあると安心して変換出来ます。
+
+面倒な時はExampleテストを追加してみるといい気がします。
+
+- [npmパッケージをExampleテストしよう | Web Scratch](http://efcl.info/2015/07/29/example-test-on-npm/ "npmパッケージをExampleテストしよう | Web Scratch")
+
+そのライブラリのユースケースを考えて幾つかのパターンを実行出来るExampleテストを作っておくと、普通に実行してエラーにならないことが保証できるのでカバレッジが上げやすい気がします。
+
+textlintの場合は[普通にコマンドラインで叩く場合](https://github.com/azu/textlint/tree/master/examples/cli)、[.textlintrcの設定ファイルを使う場合](https://github.com/azu/textlint/tree/master/examples/config-file)、[`--rulesdir`を使う場合](https://github.com/azu/textlint/tree/master/examples/rulesdir)と3つぐらいのExampleテストを事前に追加しました。
+
+- [Add exmples/ · Issue #26 · azu/textlint](https://github.com/azu/textlint/issues/26 "Add exmples/ · Issue #26 · azu/textlint")
+
+
+### [xto6](http://xto6.js.org/ "xto6")で書き換え
+
+- [JavaScript - ES5のコードをES6のコードに変換するxto6の紹介 - Qiita](http://qiita.com/yudppp/items/c6e9a825659b07da5072 "JavaScript - ES5のコードをES6のコードに変換するxto6の紹介 - Qiita")
+
+まず[xto6](http://xto6.js.org/ "xto6")を使って大雑把にコードをES6に書き換えました。
+まず、`lib/`に現状のES5なコードを置いておいて、ES6のコードを置く`src/`ディレクトリを作っておきます。
+
+```
+.
+├── LICENSE
+├── lib (ES5のコード)
+├── src (ES6用のディレクトリ)
+└── test
+```
+
+そうしたら、`lib/`ディレクトリ内で以下のようにしてそれぞれファイルを変換した感じです。
+
+```sh
+find . -type f -not -path "*node_modules*" -name "*.js" -print0 | xargs -0 -I % xto6 % -o ../src/%
+```
+
+これで、`const`とか`class`とかの書き換えはある程度いい感じにできますが、
+いくつか変換バグ的なものもありました。
+
+- コンストラクタ関数の仮引数が消える
+	- classに変換された時になぜか仮引数が消えるので付け加えた
+- `try/catch`内での`var`が`let`や`const`になって解決できなくなる
+	- Babelとかでコンパイルすれば普通にわかるのでそれで直せる
+
+とかぐらいで、[escodegen](https://github.com/estools/escodegen "escodegen")がまだES6をフルサポートしてないのもあるので、全ての変換が上手く出来るわけではないですが、意外といい感じに変換してくれると思います。
+ある程度テスト書かれてれば、テストが落ちやすい部分だったのでどこが間違ってるのか分からない的な変換はなかったと思います。
+
+### テストをES6対応する
+
+元々のテストは以下の構成でした。
+
+- [Mocha](http://mochajs.org/ "Mocha")
+- [power-assert](https://github.com/power-assert-js/power-assert)
+- [intelli-espower-loader](https://github.com/power-assert-js/intelli-espower-loader)
+
+これをテストからそのまま`src/`にあるES6のファイルを使ってテスト出来るように以下の構成に変更しました。
+
+- [Mocha](http://mochajs.org/ "Mocha")
+- [power-assert](https://github.com/power-assert-js/power-assert)
+- [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel")
+
+テストから`lib/`を参照している場合は`src/`に書き換えたのと、`mocha.opts`ファイルを一行変更しただけで済みました。
+
+```diff
+- --require intelli-espower-loader
++ --compilers js:espower-babel/guess
+```
+
+### 細かいリファクタリング
+
+xto6みたいに構造的にそのまま一致しない場合は変換できないので、いいタイミングだったので一緒にリファクタリングした。
+
+- static methodベースだったものをclassに変更
+	- [refactor(textlnt): add textlint-core class · azu/textlint@6ab9272](https://github.com/azu/textlint/commit/6ab92721eb3f2381b09b66c2ee9f41b1a4bbae40 "refactor(textlnt): add textlint-core class · azu/textlint@6ab9272")
+
+### パッケージの情報を書き換え
+
+[ライブラリをES6で書いて公開する所から始めよう](http://efcl.info/2015/01/09/write-es6/ "ライブラリをES6で書いて公開する所から始めよう | Web Scratch")でやっているES6で書いたライブラリ構成になるということなので、`package.json`を色々書き換えます。
+
+- `"main"`のパスが変わってるなら変更
+- `.gitignore`の`/lib`を追加
+- `lib/`をGitの管理下から外す
+
+### [JSCS](http://jscs.info/ "JSCS")でスタイルチェック
+
+元々[JSCS](http://jscs.info/ "JSCS")を導入してありましたが、
+[JSCS](http://jscs.info/ "JSCS")はES6も対応してるので、特に設定は必要なくそのままES6でも使えます。
+
+```
+jscs -x src/
+```
+
+`xto6`でファイル末尾の改行が消えるので、jscsの[--fix (-x)](http://jscs.info/overview#cli "--fix (-x)")オプションを使えば直せます。
+
+### おわり
+
+後はマージしてpublishしただけです。
+
+- [Release Moving to ES6 · azu/textlint](https://github.com/azu/textlint/releases/tag/3.6.1 "Release Moving to ES6 · azu/textlint")
+
+[textlint](https://github.com/azu/textlint "textlint")は元々処理をモジュールで分けて使ってるので、コアとなるのは1000行程のプロジェクトです。
+
+- [azu/txt-ast-traverse](https://github.com/azu/txt-ast-traverse)
+- [azu/textlint-formatter](https://github.com/azu/textlint-formatter)
+- [azu/markdown-to-ast](https://github.com/azu/markdown-to-ast)
+- [azu/txt-to-ast](https://github.com/azu/txt-to-ast)
+
+実際にやってみてES6だと100行弱ぐらいは減ってたので1割弱ぐらいはコードベースが小さくなる気がします。
+大部分は[xto6](http://xto6.js.org/ "xto6")の自動的な書き換えでよくて、単純にES6で動くだけの変換なら30分ぐらいでできた気がします(併せて色々リファクタリングしたのでもうちょっとかかった)
+
+書き換えたくなった理由としては、デフォルト引数使いたい場面やArrow Function使えばこの`that`いらないのにと思ったり、これclassで良いよな的な状況がちょくちょくでてきたので書き換えました。
+
+書き換えしなくてもBabelで変換するだけならES5のコードそのものをBabelで変換しても問題ないはずですが、中途半端に追加していくのはダルそうだったのでザクっと変換しました。
+
+書き換えするのにあるといいのは、カバレッジが高いテストコードですが、今回はそれの補強材として[Exampleテスト](http://efcl.info/2015/07/29/example-test-on-npm/ "Exampleテスト")を幾つか追加してから変換しました。

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "textlint-rule-no-start-duplicated-conjunction": "^1.0.6"
   },
   "scripts": {
-    "textlint": "git diff --name-only --diff-filter=ACMR origin | grep -a '_posts/.*.md$' | xargs textlint",
+    "textlint": "git diff --name-only --diff-filter=ACMR origin/master | grep -a '_posts/.*.md$' | xargs textlint",
     "test": "npm run textlint"
   },
   "repository": {

--- a/tools/review-textlint.sh
+++ b/tools/review-textlint.sh
@@ -2,7 +2,7 @@
 if [ -n "${TRAVIS_PULL_REQUEST}" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   gem install --no-document checkstyle_filter-git saddler saddler-reporter-github
 
-  diffBranchName="origin"
+  diffBranchName="origin/master"
   # 変更行のみを対象にする
   git diff --name-only --diff-filter=ACMR ${diffBranchName} \
   | grep -a '_posts/.*.md$' \


### PR DESCRIPTION
- [Release Moving to ES6 · azu/textlint](https://github.com/azu/textlint/releases/tag/3.6.1 "Release Moving to ES6 · azu/textlint")

の話