### PR TITLE
power-assertがツールとなった話

### DIFF
--- a/_posts/2016/2016-04-14-espower-babel-is-deprecated.md
+++ b/_posts/2016/2016-04-14-espower-babel-is-deprecated.md
@@ -43,15 +43,19 @@ $ migrate-espower-babel-to-babel-preset-power-assert
 
 新規で、power-assert + Mocha + Babel環境(ランタイム変換)を導入する手順です。
 
+サンプルプロジェクト
+
+- [azu/power-assert-as-tool-demo](https://github.com/azu/power-assert-as-tool-demo "azu/power-assert-as-tool-demo")
+
 ## インストール
 
 ### 必要なモジュールをインストール
 
 ```sh
-npm i -D mocha babel-register babel-preset-power-assert babel-preset-es2015
+npm i -D power-assert mocha babel-register babel-preset-power-assert babel-preset-es2015
 ```
 
-mochaからテストを実行する際に、Babelの変換を噛ませるようにするために、`babel-register`と以下の2つのpresetをインストールします。
+mochaからテストを実行する際にBabelの変換をするので、`babel-register`と以下の2つのpresetをインストールします。
 
 - babel-preset-es2015
 	- ES2015の変換を行うpreset
@@ -151,11 +155,13 @@ describe("add", function () {
 
 ![assert to be power-asssert](http://efcl.info/wp-content/uploads/2016/04/14-1460633294.png)
 
-これは、どういうことになるかというと、コード上でライブラリとして`require("power-assert")`と読み込む必要がなくなり、ツールとしてpower-assertが動くようになった事を意味します。
+これはどういうことになるかというと、コード上でライブラリとして`require("power-assert")`と読み込む必要がなくなり、ツールとしてpower-assertが動くようになった事を意味します。
 
 なので、`power-assert`を使わなくなった時はツール(具体的には`babelrc`から)power-assertを外すだけで、コードは一切変更しなくても良くなったということです。
 
 そのため、power-assertは開発用のライブラリからツールという位置づけに変わったという話でした。
+
+ここまでを適応したバージョン
 
 ## おまけ
 
@@ -202,7 +208,7 @@ JSDocから自動でランタイムAssertionを追加してくれる[babel-plugi
          "power-assert"
        ]
      }
- 
+
 diff --git a/src/add.js b/src/add.js
 index 4748ae3..5cc3b9c 100644
 --- a/src/add.js
@@ -222,8 +228,48 @@ index 4748ae3..5cc3b9c 100644
 -}
 ```
 
-変更したコミット: 
+変更したコミット:
 
 - [feat(babel): use jsdoc-to-assert by azu · Pull Request #1 · azu/power-assert-as-tool-demo](https://github.com/azu/power-assert-as-tool-demo/pull/1 "feat(babel): use jsdoc-to-assert by azu · Pull Request #1 · azu/power-assert-as-tool-demo")
 
 [babel-preset-jsdoc-to-assert](https://github.com/azu/babel-preset-jsdoc-to-assert "azu/babel-preset-jsdoc-to-assert: Babel plugin for jsdoc-to-assert")もpower-assert化できるといいのですが、Babelの変換の仕組み上難しいのでまだできてません。
+
+また、`assert`をアプリケーション側で使っていた際に、プロダクションビルドからは取り除きたいということがあります。その場合はunassertを使えば、取り除けるので便利です。
+
+- [twada/unassert: Encourage reliable programming by writing assertions in production code, and compiling them away from release](https://github.com/twada/unassert)
+- [twada/babel-plugin-unassert: Babel plugin to encourage reliable programming by writing assertions in production code, and compiling them away from release.](https://github.com/twada/babel-plugin-unassert)
+
+変更したコミット:
+
+- [feat(babel): add unassert in NODE_ENV=production building by azu · Pull Request #2 · azu/power-assert-as-tool-demo](https://github.com/azu/power-assert-as-tool-demo/pull/2 "feat(babel): add unassert in NODE_ENV=production building by azu · Pull Request #2 · azu/power-assert-as-tool-demo")
+
+ここまでを全部適応した最終的な`.bebelrc`は次のような形になっています。
+
+```js
+{
+  "presets": [
+    "es2015"
+  ],
+  "env": {
+    "development": {
+      "presets": [
+        "jsdoc-to-assert",
+        "power-assert"
+      ]
+    },
+    "production": {
+      "plugins": [
+        "babel-plugin-unassert"
+      ]
+    }
+  }
+}
+```
+
+- [azu/power-assert-as-tool-demo: babel + power-assert preset demo project.](https://github.com/azu/power-assert-as-tool-demo "azu/power-assert-as-tool-demo: babel + power-assert preset demo project.")
+
+## おわり
+
+- espower-babelはBebel5以下における解だったので、役目はひとまず終わり
+- 普通にコンパイル言語と同じように、デバッグ時のみ情報量の多いassertの適応、プロダクションビルド時は取り除くということができるようになった
+- [ホーア論理](https://ja.wikipedia.org/wiki/%E3%83%9B%E3%83%BC%E3%82%A2%E8%AB%96%E7%90%86 "ホーア論理")的な事前条件は`assert`やJSDocで、事後条件はテストで保証するみたいなことはやりやすくなった

--- a/_posts/2016/2016-04-14-espower-babel-is-deprecated.md
+++ b/_posts/2016/2016-04-14-espower-babel-is-deprecated.md
@@ -1,0 +1,158 @@
+---
+title: "power-assert + babel as a tool"
+author: azu
+layout: post
+date : 2016-04-14T19:55
+category: JavaScript
+tags:
+    - power-assert
+    - JavaScript
+    - testing
+
+---
+
+## 3行まとめ
+
+- [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel")は役目を終えたので、Deprecated
+- Babel + power-assertは[babel-preset-power-assert](https://github.com/power-assert-js/babel-preset-power-assert "babel-preset-power-assert")を使う
+- コード上は`require("power-assert")`でも、`require("assert")`でもpower-assert化できるようになった
+
+## インストール
+
+### 必要なモジュールをインストール
+
+```sh
+npm i -D mocha babel-register babel-preset-power-assert babel-preset-es2015
+```
+
+mochaからテストを実行する際に、Babelの変換を噛ませるようにするために、`babel-register`と以下の2つのpresetをインストールします。
+
+- babel-preset-es2015
+	- ES2015の変換を行うpreset
+- babel-preset-power-assert
+	- power-assert関連のpreset
+
+
+### `.babelrc`を作成
+
+Babelの設定をするために、`.babelrc`を次のように作成します。
+power-assertは開発中(テスト中)にしか必要ないので、`env`で振り分けしておきます。
+(`NODE_ENV`によって振り分けされるます。 `NODE_ENV=production <コマンド>`のような感じで指定して環境によって必要がプラグインなどを分けることができます)
+
+```json
+{
+  "presets": [
+    "es2015"
+  ],
+  "env": {
+    "development": {
+      "presets": [
+        "power-assert"
+      ]
+    }
+  }
+}
+```
+
+### `mocha.opts`を作成
+
+Mochaの設定をする`mocha.opts`を作成します。
+
+`test/mocha.opts` に以下のように書くだけです。設定ファイルとして作らないで、引数に渡すだけでいいかもしれません。
+
+```
+--compilers js:babel-register
+```
+
+こうすることで、Mochaのテスト実行時はBabelによる変換がランタイムで行われます。
+
+## テストを書く
+
+次のような足し算をするコードを書いてみます。
+
+`add.js`:
+
+```js
+"use strict";
+const assert = require("assert");
+export default function add(x, y) {
+    assert(typeof x === "number");
+    assert(typeof y === "number");
+    return x + y;
+}
+```
+
+これをテストするコードを`assert`モジュールを使って書いてみます。
+
+`add-test.js`
+
+```js
+// require("power-assert") じゃなくて assert でもいい
+const assert = require("assert");
+import add from "../src/add";
+describe("add", function () {
+    it("should return x + y", function () {
+        const result = add(1, 2);
+        assert.equal(result, 5);// <= Wrong
+    });
+});
+```
+
+`$ mocha`という感じでテストを実行してみると、このテストは`3 == 5`となっているので失敗します。
+
+![power-assert result](http://efcl.info/wp-content/uploads/2016/04/14-1460632719.png)
+
+テストを失敗すると、power-assertにより構造的な結果が表示されています。
+`.babelrc`の設定にもとづいて変換する際に`babel-preset-power-assert`が次の2つのことをやっています。
+
+1. `require("assert")`を`require("power-assert")`に書き換える
+2. `assert`関数などに仕込みをして、失敗した時に情報をいっぱい表示できるようにする
+	- こちらは今までもやっていたこと
+
+これにより、`require("power-assert")`ではなく、ただの`require("assert")`もpower-assert化された状態でassertionが行えるようになっています。
+
+通常今までは、テストコードのみ`require("power-assert")`をして、アプリケーションコード側では`require("assert")`をしていたと思います。
+
+例えば、この`add.js`の例では引数のチェックに`assert`を使っています。
+
+```js
+    it("arguments should be type of number", function () {
+        add("string", "string");
+    });
+```
+
+これもMocha経由で実行してみると、ただの`assert(typeof x === "number");`もpower-assert化されています。
+
+![assert to be power-asssert](http://efcl.info/wp-content/uploads/2016/04/14-1460633294.png)
+
+これは、どういうことになるかというと、コード上でライブラリとして`require("power-assert")`と読み込む必要がなくなり、ツールとしてpower-assertが動くようになった事を意味します。
+
+なので、`power-assert`を使わなくなった時はツール(具体的には`babelrc`から)power-assertを外すだけで、コードは一切変更しなくても良くなったということです。
+
+## おまけ
+
+アプリケーションに`assert`を書くようになったと言っても、今回の`add(x ,y)`のように決まりきったような引数のチェックを毎回書くのは大変です。
+
+先ほどの`add.js`は次のような感じでテストすることができます。
+
+```js
+const assert = require("assert");
+import add from "../src/add";
+describe("add", function () {
+    it("should return x + y", function () {
+        const result = add(1, 2);
+        assert.equal(result, 3);
+    });
+    it("arguments should be type of number", function () {
+        try {
+            add("string", "string");
+
+            throw new Error("unreachable line");
+        } catch (error) {
+            assert(error instanceof assert.AssertionError);
+        }
+    });
+});
+```
+
+引数の型違反例外(`assert.AssertionError`)もテストされていることが分かります。


### PR DESCRIPTION
- [x] [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel")をdeprecatedにする
- [ ] https://github.com/azu/babel-plugin-auto-import-assert + https://github.com/azu/babel-plugin-jsdoc-to-assert + power-assertをしたいがBabelがむずそう `passPerPreset` する必要があるかつ、ASTをイジった結果にlocとかがないといけない
- [ ] [テストコードをES6+power-assertで書けるespower-babel 3.0.0リリース | Web Scratch](http://efcl.info/2015/05/10/espower-babel3.0.0/ "テストコードをES6+power-assertで書けるespower-babel 3.0.0リリース | Web Scratch")を更新する
- [x] Add https://github.com/azu/power-assert-as-tool-demo