### PR TITLE
Fix for 404 link in 2014-12-30-textlint

### DIFF
--- a/_posts/2014/2014-12-30-textlint.md
+++ b/_posts/2014/2014-12-30-textlint.md
@@ -26,7 +26,7 @@ tags:
 
 逆にデフォルトではルールはサンプル扱いの`no-todo`というTODOが含まれてることを検知するルールしか今のところ入れていません。
 
-- [Example: creating no-todo rules.](https://github.com/azu/textlint/blob/master/docs/create-rules.md#example-creating-no-todo-rules "Example: creating no-todo rules.")
+- [Example: creating no-todo rules.](https://github.com/textlint/textlint/blob/master/docs/rule.md#example-creating-no-todo-rules "Example: creating no-todo rules.")
 
 
 デフォルトでルールが用意されていて、それの設定を変更することでLintする場合はRedPenなどがお勧めです。


### PR DESCRIPTION
リンク切れが起きていたので，リンクを新しい場所?と思われる場所に向け直しました．

リンクが切れる前はその先がどのような記事だったか見ていないので，もしかしたら間違っているかもしれません．
ご確認をお願いいたします．