### PR TITLE
fix(jekyll): fix ogp:image generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ url: "http://efcl.info"
 baseurl: ""
 production_url : "http://efcl.info"
 github_repo_url : https://github.com/efcl/efcl.github.io
+icon: "/public/favicon.ico"
 timezone: Asia/Tokyo
 encoding: utf-8
 exclude:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
     <!-- Icons -->
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
           href="{{ site.baseurl }}/public/apple-touch-icon-144-precomposed.png">
-    <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
+    <link rel="shortcut icon" href="{{ site.icon | prepend: site.baseurl | prepend: site.url }}">
 
     <!-- RSS -->
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed/">

--- a/_includes/ogp.html
+++ b/_includes/ogp.html
@@ -2,7 +2,7 @@
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 <meta property="og:type" content="{% if page.date %}article{% else %}website{% endif %}">
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-<meta property="og:image" content="{% if img_src %}{{ img_src }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
+<meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
 
 <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 <meta property="og:site_name" content="{{ site.title }}">


### PR DESCRIPTION
現時点では画像でない `http://efcl.info`  が必ず生成されます。