### PR TITLE
Add CSP report

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,8 @@ github_repo_url : https://github.com/efcl/efcl.github.io
 icon: "/public/favicon.ico"
 timezone: Asia/Tokyo
 encoding: utf-8
+include:
+  - _headers
 exclude:
   - README.md
   - config.rb

--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy-Report-Only: default-src https:;

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -6,4 +6,6 @@
 
     ga('create', 'UA-2184335-8', 'auto');
     ga('send', 'pageview');
+    ga('require', 'csp-report');
 </script>
+<script async src='https://unpkg.com/csp-report-to-google-analytics/dist/csp-report-to-google-analytics.min.js'></script>


### PR DESCRIPTION
#153 It is a parts of migration to Https

I've created CSP report plugin for google analytics

[azu/csp-report-to-google-analytics: CSP report to Google Analytics.](https://github.com/azu/csp-report-to-google-analytics "azu/csp-report-to-google-analytics: CSP report to Google Analytics.")

- Add `Content-Security-Policy-Report-Only: default-src https:;` to Netlify's header
  - [Headers & Basic Authentication | Netlify](https://www.netlify.com/docs/headers-and-basic-auth/ "Headers &amp; Basic Authentication | Netlify")
