### PR TITLE
Replaced dead link with another regex tester

### DIFF
--- a/_posts/2010/2010-09-14-javascript関係のツールまとめてみた.md
+++ b/_posts/2010/2010-09-14-javascript関係のツールまとめてみた.md
@@ -34,7 +34,7 @@ tags:
 *   [jsPerf][6]  
     `benchmark.js`を使った比較ツール。JavaScriptのスニペットを登録して処理時間を比較できる。  
     実行結果がサイトに記録されるので、他人がやった結果がどんどん貯まるのも良い点。
-*   [HiFi Regex Tester][7]  
+*   [ExtendsClass Regex Tester][7]  
     JavaScriptの正規表現を確認できるツール。  
     類似:[RegExpChecker.js][8]  
     正規表現関係で、正規表現をオートマトン的に図示してくれる[strfriend][9]も便利です。
@@ -70,7 +70,7 @@ tags:
  [4]: http://gist.github.com/
  [5]: http://userscripts.org/scripts/show/71914
  [6]: http://jsperf.com/
- [7]: http://www.gethifi.com/tools/regex
+ [7]: https://extendsclass.com/regex-tester.html
  [8]: http://mrgoofy.web.fc2.com/jsarcv/regexp/
  [9]: http://strfriend.com/
  [10]: http://prettydiff.com/


### PR DESCRIPTION
Hello, there is a dead link to Hifi regex tester.
I replaced this dead link with a link to extendsclass regex tester (I am the founder).