### PR TITLE
feat: jsprimer 4.0.0

### DIFF
--- a/_posts/2022/2022-06-19-jsprimer-4.md
+++ b/_posts/2022/2022-06-19-jsprimer-4.md
@@ -1,0 +1,310 @@
+---
+title: "JavaScript Primer 4.0.0: ECMAScript 2022に対応したJS本"
+author: azu
+layout: post
+date : 2022-06-19T21:38
+category: JavaScript
+tags:
+    - JavaScript
+    - Book
+
+---
+
+JavaScript Primer([jsprimer.net](https://jsprimer.net/))が、ECMAScript 2022(ES2022)に対応しました。
+
+- リリースノート: [Release v4.0.0: ES2022 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/releases/tag/v4.0.0)
+
+## これまでのjsprimer
+
+ECMAScriptの仕様書は毎年更新されるので、それに合わせて[jsprimer](https://jsprimer.net/)も更新しています。
+
+- 1.0.0(ES2019): [JavaScript Primerを出版しました！/JavaScript Primerはなぜ書かれたのか？](https://efcl.info/2020/04/27/jsprimer/)
+- 2.0.0(ES2020): [JavaScript Primer 2.0 - ECMAScript 2020に対応した入門書を公開しました](https://efcl.info/2020/09/01/jsprimer-2.0/)
+- 3.0.0(ES2021): [ES2021に対応したJavaScript Primer 3.0を公開しました - JavaScript入門](https://efcl.info/2021/06/28/jsprimer-3.0/)
+
+今回のアップデートでは、2022-6-XXにリリースされたES2022に対応した変更をしています。
+
+今後GitHubで更新情報を購読したい人は、[asciidwango/js-primer](https://github.com/asciidwango/js-primer)リポジトリを["Watch"](https://github.com/asciidwango/js-primer/watchers)してください。
+"Custom"からリリースのみを購読も可能です。
+
+[![GitHub Watchesの登録画面](https://user-images.githubusercontent.com/19714/123548584-52debb80-d7a0-11eb-9a8c-a975b9e6c795.png)](https://github.com/asciidwango/js-primer/watchers)
+
+更新通知をメールで受け取り方は、次のフォームからメールアドレスを登録してください。
+
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+    #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+</style>
+<div id="mc_embed_signup">
+<form action="https://github.us13.list-manage.com/subscribe/post?u=fc41e11a2b9dc6f05350e0de0&amp;id=7ab1594ae8" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+    <h2>JavaScript Primerの更新情報を購読</h2>
+<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+<div class="mc-field-group">
+    <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+</label>
+    <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+    <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+    </div>
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fc41e11a2b9dc6f05350e0de0_7ab1594ae8" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+
+フォームが表示されない人は <http://eepurl.com/gZOIgb> から登録できます。
+
+今回のアップデートのような大きめな更新情報をメールで受け取れます。
+
+## 書籍への支援について
+
+継続的にアップデートするために、書籍への支援はいつでも歓迎しています。
+JavaScript PrimerはECMAScriptのアップデートに追従したり、現実の使い方を反映するために、継続してアップデートしています。
+
+GitHub Sponsorsで著者を支援できます。
+
+- [Sponsor @azu on GitHub Sponsors](https://github.com/sponsors/azu)
+
+また、書籍版へのレビューを書くことも支援に繋がります。
+
+- [JavaScript Primer 迷わないための入門書 | azu, Suguru Inatomi |本 | 通販 | Amazon](https://www.amazon.co.jp/dp/4048930737/)
+
+GitHubのDiscussions（掲示板）の他の人の質問に答えたり、ブログにjsprimerを読んだ感想を書くことも支援になります。
+
+- [Discussions · asciidwango/js-primer](https://github.com/asciidwango/js-primer/discussions)
+
+Discussionsのガイドラインは次のスレッドにまとめられています。
+
+- [👋 ようこそ JavaScript Primer へ ! · Discussion #1304 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/discussions/1304)
+
+書籍に対してIssueを立てたり、Pull Requestを送ったりして直接的に支援もできます。
+IssueやPull Requestについては、次のページを参照してください。
+
+- [文章の間違いに気づいたら · JavaScript Primer #jsprimer](https://jsprimer.net/intro/feedback/)
+
+## jsprimerの今後について
+
+まだ詳細は未決定ですが、書籍版の改訂を進めていくための作業をしていく予定です。
+
+書籍版の初版はES2019相当がベースにしたスナップショットとなっています。
+現在のウェブ版はES2020/ES2021/ES2022の対応で内容を変更したり追加しているため、あらためて全体を見て読みやすく調整していく作業をしていく予定です。
+
+特に[クラス](https://jsprimer.net/basic/class/)と[非同期処理](https://jsprimer.net/basic/async/)は、もともと内容が難しいのに加えて長くなってしまってるので、これを読みやすくするアイデアとか意見を募集しています。
+
+それぞれDiscussionのスレを作ってあるので、こうだったら分かりやすくなりそうとか、ここら辺がわかりにくかったとかの意見やアイデアがあったらコメントください。
+
+- クラス: [クラスの改善案を募集 · Discussion #1443](https://github.com/asciidwango/js-primer/discussions/1443)
+- 非同期処理: [非同期の章の改善案を募集 · Discussion #1444](https://github.com/asciidwango/js-primer/discussions/1444)
+
+また、次の改訂に向けてある程度内容が整理できてきたら、あらためて全体をレビューしてもらえる人を募集しています。
+もし、レビューできるよって方がいたら、Twitterか次のDiscussionにコメントください。
+依頼するタイミングになったらあらためてお知らせします。
+
+- Discussion: [[予定] 次の版のレビュアーを募集 · Discussion #1445 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/discussions/1445)
+
+前回レビューしていただいた方は、書面にも掲載させていただいています。
+
+- <https://jsprimer.net/intro/#thanks>
+
+## jsprimer 4.0.0の変更点
+
+[jsprimer.net](https://jsprimer.net/) 4.0.0の変更点の紹介です。
+
+- Issue: [ECMAScript 2022対応 · Issue #1337 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/1337)
+- Release Note: [Release v4.0.0: ES2022 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/releases/tag/v4.0.0)
+
+ES2022への対応して、次の内容が更新されています。
+また、ウェブ版の仕組みとしてユースケースの章などのHTMLを使ったアプリケーションもウェブ上でそのまま変更しながら確認できるエディタを組み込んでいます。
+
+## Top-Level `await`
+
+> https://jsprimer.net/basic/async/#top-level-await-in-module
+
+ES2021までは、`await`式はAsync Functionの直下でのみしか利用できませんでした。
+ES2022には、これに加えてModuleの直下では、Async Functionで囲まなくても`await`式が利用できます。
+
+```js
+console.log("start");
+// awaitを使って1秒待つ
+await new Promise(resolve => setTimeout(resolve, 1000));
+console.log("end");
+```
+
+これにより、`await`式を使うためだけにAsync Functionを使った即時実行関数は不要となります。
+
+```js
+// awaitを使うためだけに、Async Functionの即時実行関数を実行している
+(async function() {
+    // awaitを使う処理
+    const result = await doAsyncTask();
+    // ...
+})();
+```
+
+## `Object.hasOwn`
+
+> https://jsprimer.net/basic/object/
+
+ES2022では`Object.hasOwn`静的メソッドが追加されました。
+`Object.hasOwn`静的メソッドは、対象のオブジェクトが指定したプロパティを持っているかを確認できるメソッドです。
+
+```js
+const obj = { key: "value" };
+// `obj`が`key`プロパティを持っているならtrueとなる
+if (Object.hasOwn(obj, "key")) {
+    console.log("`obj`は`key`プロパティを持っている");
+}
+```
+
+この`Object.hasOwn`静的メソッドは、`Object.prototype.hasOwnProperty`メソッドを置き換える目的で導入されています。
+
+`hasOwnProperty`メソッドは、`Object.create(null)`で作成したような"prototypeを継承していないオブジェクト"からは直接呼び出せないという欠点があります。
+
+```js
+// prototypeを継承していないオブジェクト
+const obj = Object.create(null);
+// `Object.prototype`を継承していないため呼び出すと例外が発生する
+console.log(obj.hasOwnProperty("key")); // => Error: hasOwnPropertyメソッドは呼び出せない
+```
+
+`Object.hasOwn`静的メソッドは、インスタンスオブジェクトではなく静的メソッドであるため、対象のオブジェクトに関係なく利用できます。
+
+```js
+// prototypeを継承していないオブジェクト
+const mapLike = Object.create(null);
+// keyは存在しない
+console.log(Object.hasOwn(mapLike, "key")); // => false
+```
+
+## `Array.prototype.at`
+
+> https://jsprimer.net/basic/array/
+
+配列の末尾の要素へアクセスするには、`array[array.length - 1]`という`length`プロパティを使う必要がありました。
+`array`を2回書く必要があるなど、末尾の要素へのアクセスは少し手間が必要になっていました。
+
+この問題を解決するためES2022では、相対的なインデックスの値を指定して配列の要素へアクセスできる`Array.prototype.at`メソッドが追加されました。
+Arrayの`at`メソッドは、`配列[インデックス]`とよく似ていますが、引数には相対的なインデックスの値を引数として渡せます。`.at(0)`なら配列の先頭の要素へ、`.at(-1)`なら配列の末尾の要素へアクセスできます。
+
+```js
+const array = ["a", "b", "c"];
+// 先頭の要素にアクセス
+console.log(array.at(0)); // => "a"
+console.log(array[0]); // => "a"
+// 後ろから1つ目の要素にアクセス
+console.log(array.at(-1)); // => "c"
+console.log(array[array.length - 1]); // => "c"
+```
+
+## `String.prototype.at`
+
+> https://jsprimer.net/basic/string/
+
+配列と同じく文字列にも相対的なインデックスの値を指定して文字へアクセスできる`String.prototype.at`が追加されました。
+
+```js
+const str = "文字列";
+console.log(str.at(0)); // => "文"
+console.log(str.at(1)); // => "字"
+console.log(str.at(2)); // => "列"
+console.log(str.at(-1)); // => "列"
+```
+
+## Public/Privateクラスフィールド
+
+- [クラス · JavaScript Primer #jsprimer](https://jsprimer.net/basic/class/)
+- [Todoアプリ · JavaScript Primer #jsprimer](https://jsprimer.net/use-case/todoapp/)
+
+ES2022ではクラスにクラスフィールド構文が追加されました。
+
+クラスフィールドは、PublicクラスフィールドとPrivateクラスフィールドの2種類があります。
+Publicクラスフィールドは、次のようにクラスのインスタンスに対するプロパティを宣言的に定義できる構文です。
+
+```js
+class Counter {
+    count = 0;
+    increment() {
+        this.count++;
+    }
+}
+const counter = new Counter();
+counter.increment();
+console.log(counter.count); // => 1
+```
+
+一方のPrivateクラスフィールドは、フィールド名の前に`#`をつけることで、クラスの外からはアクセスできないプライベートなプロパティを定義できる構文です。
+
+```js
+class NumberWrapper {
+    // valueはPrivateクラスフィールドとして定義
+    #value;
+    constructor(value) {
+        this.#value = value;
+    }
+    // `#value`フィールドの値を返すgetter
+    get value() {
+        return this.#value;
+    }
+    // `#value`フィールドに値を代入するsetter
+    set value(newValue) {
+        this.#value = newValue;
+    }
+}
+
+const numberWrapper = new NumberWrapper(1);
+console.log(numberWrapper.value); // => 1
+// クラスの外からPrivateクラスフィールドには直接はアクセスできない
+// console.log(numberWrapper.#value); // => SyntaxError: reference to undeclared private field or method #value
+```
+
+今までは、クラスのインスタンスにプロパティを定義するにはクラスの`constructor`メソッド内で値を代入する必要がありました。クラスフィールドでは、インスタンスへのプロパティの定義をより宣言的に行えます。
+
+## その他
+
+そのほかにもES2022ではRegular expression match indices、スタックトレースを継承するError cause、 static blocksなどが追加されています。
+
+## ウェブエディタの改善
+
+jsprimer.net のウェブ版では、JavaScriptのコードをそのままブラウザで実行できるコンソール機能が実装されています。
+
+今までは、JavaScript実行のみしか扱えませんでしたが、そのため表示を扱うユースケースである[Todoアプリ](https://jsprimer.net/use-case/todoapp/)などはローカルサーバを使って確認する必要がありました。
+今回、jsprimerにHTMLの表示も伴うコードにも対応したエディタを組み込みました。
+
+![Sandpack on jsprimer](https://user-images.githubusercontent.com/19714/175033435-3f74dc30-2b7d-4d38-8da7-97361b018766.png)
+
+
+[CodeSandbox](https://codesandbox.io)が提供している[Component toolkit for creating live-running code editing experiences | Sandpack](https://sandpack.codesandbox.io)を使いエディタを組み込んでいます。
+エディタの右下のボタンから、CodeSandboxで開いてコードを共有も可能です。
+
+## これからjsprimer読む方へ
+
+[JavaScript Primer - 迷わないための入門書 #jsprimer](https://jsprimer.net/)をまだ読んだことなくて、これから読みたい方へ。
+
+書籍版の内容はウェブ版と基本的に同じですが、本として読めるように内容とレイアウトが最適化されています。
+また、書籍版はある時点(ES2019)のスナップショットで、ウェブ版は常にアップデートされています。
+
+書籍版は細かく校正を行った後にレイアウトを組んで作っているため、読み物としては書籍版の方が読みやすくなっています。
+一方のウェブ版は、最新(ES2022)の仕様を含めた変更を取り入れています。
+また、ウェブ版では検索機能やサンプルコードを実行できる機能が組み込まれているため、必要に応じて併用してください。
+
+詳細は次のページでも書いています。
+
+- [ウェブ版と書籍版の違い](https://jsprimer.net/intro/#diff-with-print-version)
+
+jsprimerをちょっとづつ読んでいきたい方向けに、チェックリストも用意してあります。
+章ごとにチェックして進められるので、章ごとにわからなかった部分をメモしたりして自分のペースで進めるための補助的なツールとして使ってください。
+
+- [x] Google SpreadSheet
+  - https://docs.google.com/spreadsheets/d/15SMJj7o0LxiMvYwmi5Awqg3gwbKinKSLXj-S71GG_b8/edit#gid=0
+  - メニュー → ファイル → コピーを作成
+- [x] Markdown
+  - https://gist.github.com/azu/79bd132ab6778fdf6965715877feb470
+  - [Raw](https://gist.githubusercontent.com/azu/79bd132ab6778fdf6965715877feb470/raw/7614a5100878fe27b95a350dabbe06c9b5f192dc/jsprimer-checklist.md)ボタンからコピーできます。
+- [x] Notion
+  - https://efcl.notion.site/JavaScript-Primer-30f33336679840dea2c4a613df8ca099
+  - 右上のメニューから"複製"できます
+

--- a/_posts/2022/2022-06-19-jsprimer-4.md
+++ b/_posts/2022/2022-06-19-jsprimer-4.md
@@ -22,7 +22,9 @@ ECMAScriptの仕様書は毎年更新されるので、それに合わせて[jsp
 - 2.0.0(ES2020): [JavaScript Primer 2.0 - ECMAScript 2020に対応した入門書を公開しました](https://efcl.info/2020/09/01/jsprimer-2.0/)
 - 3.0.0(ES2021): [ES2021に対応したJavaScript Primer 3.0を公開しました - JavaScript入門](https://efcl.info/2021/06/28/jsprimer-3.0/)
 
-今回のアップデートでは、2022-6-XXにリリースされたES2022に対応した変更をしています。
+今回のアップデートでは、2022-6-22にリリースされたES2022に対応した変更をしています。
+
+- <https://www.ecma-international.org/news/ecma-international-approves-new-standards-5/>
 
 今後GitHubで更新情報を購読したい人は、[asciidwango/js-primer](https://github.com/asciidwango/js-primer)リポジトリを["Watch"](https://github.com/asciidwango/js-primer/watchers)してください。
 "Custom"からリリースのみを購読も可能です。

--- a/_posts/2022/2022-06-19-jsprimer-4.md
+++ b/_posts/2022/2022-06-19-jsprimer-4.md
@@ -112,7 +112,7 @@ IssueやPull Requestについては、次のページを参照してください
 
 - <https://jsprimer.net/intro/#thanks>
 
-## jsprimer 4.0.0の変更点
+## JavaScript Primer 4.0.0の変更点
 
 [jsprimer.net](https://jsprimer.net/) 4.0.0の変更点の紹介です。
 


### PR DESCRIPTION
JavaScript Primer 4.0.0のリリースノート

- [Release v4.0.0: ES2022 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/releases/tag/v4.0.0)
