### PR TITLE
2024-02-08-javascript-info.md の誤字を修正

### DIFF
--- a/_posts/2024/2024-02-08-javascript-info.md
+++ b/_posts/2024/2024-02-08-javascript-info.md
@@ -252,7 +252,7 @@ https://b.hatena.ne.jp/{user}/favorite.rss
 
 #### GitHubでフォローしてる人がStarしたリポジトリ
 
-[starseeker](https://starseeker.so/)は、GitHubのフォロワーがStarしたリポジトリを購読できるサービスです。
+[starseeker](https://starseeker.so/)は、GitHubでフォローしてる人がStarしたリポジトリを購読できるサービスです。
 
 GitHubでフォローしてる人は興味が似ていると思うので、そういったリポジトリを発見できます。
 


### PR DESCRIPTION
[starseeker](https://starseeker.so/)のサイトには「Seek your following's stars!」とあるので、フォロワーではなくフォロイーのことだと思います。
しかしながら、「フォロイー」という言葉は「フォロワー」と比べると世間に浸透してなさそうなので、見出しの「フォローしてる人」という表現に合わせました。
