### PR TITLE
feat: add Jekyll preview configuration for Claude Code

### DIFF
--- a/.claude/jekyll-serve.sh
+++ b/.claude/jekyll-serve.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+for rbenv_bin in "$HOME/.rbenv/bin/rbenv" /opt/homebrew/bin/rbenv /usr/local/bin/rbenv; do
+  if [ -x "$rbenv_bin" ]; then
+    eval "$($rbenv_bin init -)"
+    break
+  fi
+done
+exec bundle exec jekyll serve --livereload --limit_posts 5

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "jekyll",
+      "runtimeExecutable": ".claude/jekyll-serve.sh",
+      "runtimeArgs": [],
+      "port": 4000
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `.claude/launch.json` を追加して `preview_start` ツールで Jekyll を起動できるようにした
- `.claude/jekyll-serve.sh` を追加して rbenv を環境非依存で自動検出（Apple Silicon / Intel 両対応）
- `--livereload` でファイル変更時に自動リロード
- `--limit_posts 5` でビルド時間を約3秒に短縮

## Test plan

- [ ] `preview_start` で Jekyll サーバーが起動することを確認
- [ ] 最新記事が表示されることを確認
- [ ] ファイル変更時に LiveReload が動作することを確認